### PR TITLE
Simplify signup process

### DIFF
--- a/src/app/components/CreateWorkspace.tsx
+++ b/src/app/components/CreateWorkspace.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { VStack, Box } from '@chakra-ui/react';
+import {VStack, Box, Select} from '@chakra-ui/react';
 import {
   FormControl,
   FormLabel,
@@ -20,6 +20,7 @@ const CreateWorkspace = (props: { currentUser: CurrentUser }) => {
     CREATE_WORKSPACE_MUTATION,
   );
   const [workspaceName, setWorkspaceName] = useState<string>(domain);
+  const [numOfEmployees, setNumOfEmployees] = useState<string>(domain);
   const [autoJoinWorkspace, setAutoJoinWorkspace] = useState<boolean>(true);
   const onSubmit = async e => {
     e.preventDefault();
@@ -34,6 +35,7 @@ const CreateWorkspace = (props: { currentUser: CurrentUser }) => {
     window.analytics.track('Workspace Created', {
       workspaceTitle: domain,
       createdBy: currentUser.email,
+      numOfEmployees,
     });
   };
 
@@ -65,6 +67,25 @@ const CreateWorkspace = (props: { currentUser: CurrentUser }) => {
               Let people signing up from <strong>{domain}</strong> auto join
               your workspace?
             </FormLabel>
+          </FormControl>
+          <FormControl mt={4}>
+            <FormLabel htmlFor="number-of-employees">
+              Number of Employees
+            </FormLabel>
+            <Select
+                value={numOfEmployees}
+                isRequired
+                id="number-of-employees"
+                name="numOfEmployees"
+                onChange={e => setNumOfEmployees(e.target.value)}
+            >
+              <option value="">Select the number of employees</option>
+              <option value="1-10">1-10</option>
+              <option value="11-50">11-50</option>
+              <option value="51-200">51-200</option>
+              <option value="201-500">201-500</option>
+              <option value="500+">500+</option>
+            </Select>
           </FormControl>
           <Button
             colorScheme="brand"

--- a/src/app/components/WelcomeToDistilled.tsx
+++ b/src/app/components/WelcomeToDistilled.tsx
@@ -41,7 +41,7 @@ const WelcomeToDistilled = () => {
 
       <Box>
         <Text fontSize={'6xl'} fontWeight="extrabold">
-          Hello {data.currentUser.name?.split(' ')[0]} 🤙
+          Hello {data.currentUser?.firstName} 🤙
         </Text>
         <Text fontSize={'md'} color={'gray.700'}>
           Here's a guide on how you can start using Distilled.

--- a/src/app/lib/fragments/Plan.ts
+++ b/src/app/lib/fragments/Plan.ts
@@ -7,7 +7,8 @@ export const GOAL_FRAGMENT = gql`
     expiresOn
     createdAt
     owner {
-      name
+      firstName
+      lastName
       profilePic
     }
     measurementsCount
@@ -27,7 +28,8 @@ export const SUCCESS_CRITERIA_FRAGMENT = gql`
     goalId
     createdAt
     owner {
-      name
+      firstName
+      lastName
       profilePic
     }
     completion
@@ -77,7 +79,8 @@ export const GOAL_DETAILS_FRAGMENT = gql`
     expiresOn
     createdAt
     owner {
-      name
+      firstName
+      lastName
       profilePic
     }
     completion

--- a/src/app/lib/mutations/Auth.ts
+++ b/src/app/lib/mutations/Auth.ts
@@ -21,8 +21,8 @@ export const CREATE_AUTH = gql`
 `;
 
 export const SIGNUP = gql`
-  mutation Signup($email: String!, $password: String!, $name: String!) {
-    signUp(email: $email, password: $password, name: $name) {
+  mutation SignUp($email: String!, $password: String!, $firstName: String!, $lastName: String!, $company: String!, $position: String!) {
+    signUp(email: $email, password: $password, firstName: $firstName, lastName: $lastName, company: $company, position: $position) {
       sessionId
     }
   }

--- a/src/app/lib/mutations/User.ts
+++ b/src/app/lib/mutations/User.ts
@@ -2,10 +2,11 @@ import { gql } from '@apollo/client';
 
 // Define mutation
 export const UPDATE_USER_MUTATION = gql`
-  mutation updateUser($name: String!) {
-    updateUser(name: $name) {
+  mutation updateUser($firstName: String!, $lastName: String!) {
+    updateUser(firstName: $firstName, lastName: $lastName) {
       user {
-        name
+        firstName
+        lastName
         email
       }
     }

--- a/src/app/lib/mutations/Workspace.ts
+++ b/src/app/lib/mutations/Workspace.ts
@@ -25,8 +25,8 @@ export const UPDATE_WORKSPACE_MUTATION = gql`
 `;
 
 export const CREATE_WORKSPACE_MEMBER = gql`
-  mutation createWorkspaceMember($email: String!, $name: String!) {
-    createWorkspaceMember(email: $email, name: $name) {
+  mutation createWorkspaceMember($email: String!, $firstName: String!, $lastName: String!) {
+    createWorkspaceMember(email: $email, firstName: $firstName, lastName: $lastName) {
       workspaceMember {
         id
       }

--- a/src/app/lib/queries/User.ts
+++ b/src/app/lib/queries/User.ts
@@ -5,7 +5,10 @@ export const CURRENT_USER = gql`
     currentUser {
       id
       email
-      name
+      firstName
+      lastName
+      position
+      company
       workspaces {
         id
         title

--- a/src/app/lib/queries/Workspace.ts
+++ b/src/app/lib/queries/Workspace.ts
@@ -12,7 +12,8 @@ export const GET_WORKSPACE_DETAILS = gql`
       workspaceMembers {
         id
         user {
-          name
+          firstName
+          lastName
           id
           email
         }

--- a/src/app/pages/Dashboard/NewWorkspaceMemberModal.tsx
+++ b/src/app/pages/Dashboard/NewWorkspaceMemberModal.tsx
@@ -32,19 +32,21 @@ const NewWorkspaceMemberModal = (props: {
     CREATE_WORKSPACE_MEMBER,
   );
   const [email, setEmail] = useState<string>('');
-  const [name, setName] = useState<string>('');
+  const [firstName, setFirstName] = useState<string>('');
+  const [lastName, setLastName] = useState<string>('');
   const { isOpen, onClose } = props;
   const NewMemberInvite = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const data = await createWorkspaceMember({
       variables: {
-        name,
+        firstName,
+        lastName,
         email,
       },
     });
     if (data) {
       window.analytics.track('Workspace Member Added', {
-        workspaceMemberName: name,
+        workspaceMemberName: [firstName, lastName].join(' '),
         workspaceMemberEmail: email,
       });
       toast({
@@ -54,7 +56,8 @@ const NewWorkspaceMemberModal = (props: {
       });
       props.onClose();
       setEmail('');
-      setName('');
+      setFirstName('');
+      setLastName('');
     }
   };
 
@@ -70,15 +73,27 @@ const NewWorkspaceMemberModal = (props: {
           <form onSubmit={NewMemberInvite}>
             <VStack spacing={4} alignItems={'flex-start'}>
               <FormControl size={'xs'}>
-                <FormLabel fontSize={'sm'}>Name</FormLabel>
+                <FormLabel fontSize={'sm'}>First Name</FormLabel>
                 <Input
                   type="text"
-                  value={name}
+                  value={firstName}
                   fontSize={'sm'}
                   required
                   size={'sm'}
                   autoFocus
-                  onChange={e => setName(e.target.value)}
+                  onChange={e => setFirstName(e.target.value)}
+                />
+              </FormControl>
+              <FormControl size={'xs'}>
+                <FormLabel fontSize={'sm'}>Last Name</FormLabel>
+                <Input
+                    type="text"
+                    value={lastName}
+                    fontSize={'sm'}
+                    required
+                    size={'sm'}
+                    autoFocus
+                    onChange={e => setLastName(e.target.value)}
                 />
               </FormControl>
               <FormControl size={'xs'}>

--- a/src/app/pages/OnboardingPage/OnboardingPage.tsx
+++ b/src/app/pages/OnboardingPage/OnboardingPage.tsx
@@ -177,25 +177,6 @@ export default function Onboarding() {
               <option value="product-manager">Project Manager</option>
             </Select>
           </FormControl>
-
-          <FormControl mt={4}>
-            <FormLabel htmlFor="number-of-employees">
-              Number of Employees!
-            </FormLabel>
-            <Select
-              {...register('numOfEmployees')}
-              isRequired
-              id="number-of-employees"
-              name="numOfEmployees"
-            >
-              <option value="">Select the number of employees</option>
-              <option value="1-10">1-10</option>
-              <option value="11-50">11-50</option>
-              <option value="51-200">51-200</option>
-              <option value="201-500">201-500</option>
-              <option value="500+">500+</option>
-            </Select>
-          </FormControl>
         </Box>
       ),
     },

--- a/src/app/pages/SettingsPage/UserSettings.tsx
+++ b/src/app/pages/SettingsPage/UserSettings.tsx
@@ -8,7 +8,8 @@ import { useQuery, useMutation } from '@apollo/client';
 import { useToast } from '@chakra-ui/react';
 
 type Form = {
-  name: string;
+  firstName: string;
+  lastName: string;
   email: string;
 };
 
@@ -18,14 +19,15 @@ const UserSettingsForm = (props: { data: Form }) => {
   const [updateUserMutation, { loading }] = useMutation(UPDATE_USER_MUTATION);
 
   const [form, setForm] = useState<Form>({
-    name: data.name || '',
+    firstName: data.firstName || '',
+    lastName: data.lastName || '',
     email: data.email,
   });
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     await updateUserMutation({
-      variables: { name: form.name },
+      variables: { firstName: form.firstName, lastName: form.lastName },
       refetchQueries: [{ query: CURRENT_USER }],
     });
     toast({
@@ -50,13 +52,23 @@ const UserSettingsForm = (props: { data: Form }) => {
           />
         </FormControl>
         <FormControl>
-          <FormLabel fontSize={'sm'}>Name</FormLabel>
+          <FormLabel fontSize={'sm'}>First Name</FormLabel>
           <Input
             size={'sm'}
             type="text"
-            value={form.name}
+            value={form.firstName}
             required={true}
-            onChange={e => setForm({ ...form, name: e.target.value })}
+            onChange={e => setForm({ ...form, firstName: e.target.value })}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel fontSize={'sm'}>Last Name</FormLabel>
+          <Input
+              size={'sm'}
+              type="text"
+              value={form.lastName}
+              required={true}
+              onChange={e => setForm({ ...form, lastName: e.target.value })}
           />
         </FormControl>
         <Box marginTop={'24px !important'}>

--- a/src/app/pages/SignupPage/index.tsx
+++ b/src/app/pages/SignupPage/index.tsx
@@ -1,203 +1,319 @@
 import * as React from 'react';
-import { Helmet } from 'react-helmet-async';
 import {
-  Center,
-  Box,
-  Input,
-  Stack,
-  FormControl,
-  FormLabel,
-  Button,
-  VStack,
-  Divider,
-  Text,
-  Link,
-  Grid,
-  HStack,
-  Alert,
-  AlertIcon,
-  AlertTitle,
-  AlertDescription,
+  Center,  Box,  Input,  Stack,  FormControl,  FormLabel,  Button,  Divider,  Text,  Link,  Grid,  HStack, Select, Flex,
+  Heading, Spacer,
 } from '@chakra-ui/react';
 import { useMutation } from '@apollo/client';
 import { SIGNUP, onSignIn } from 'app/lib/mutations/Auth';
 import { useNavigate } from 'react-router-dom';
-import * as animationData from 'app/jsons/LoginAnimation.json';
 import Lottie from 'react-lottie';
 import GoogleIcon from 'app/icons/Google';
 import useGoogleOauth from 'app/lib/hooks/oauth/useGoogleOauth';
+import { useForm } from 'react-hook-form';
+import { Step, Steps, useSteps } from 'chakra-ui-steps';
+import { FiClipboard, FiUser } from 'react-icons/fi';
+import * as animationDataComplete from 'app/jsons/checkmark.json';
+import * as animationDataHero from 'app/jsons/LoginAnimation.json';
 declare const window: any;
 
-const { useState } = React;
+type FormValues = {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  company: string;
+  position: string;
+};
+
 export function Signup() {
-  const { onClick } = useGoogleOauth();
-  const [signUp, { loading, error }] = useMutation(SIGNUP);
+  const {
+    register,
+    formState: { errors },
+    getValues,
+  } = useForm<FormValues>();
+  const { nextStep, activeStep } = useSteps({ initialStep: 0 });
   const navigate = useNavigate();
-  const [name, setName] = useState<string>('');
-  const [login, setLogin] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
-  const [publicEmailErrorMessage, setPublicEmailErrorMessage] =
-    useState<string>('');
-  const [passwordErrorMessage, setPasswordErrorMessage] = useState<string>('');
+  const [signUp, { loading }] = useMutation(SIGNUP);
+  const { onClick } = useGoogleOauth();
 
-  const emailValidationRegex =
-    /^(?!.*@(gmail|yahoo|hotmail|aol|outlook|icloud|protonmail|hubspot|zoho)\.[a-z]{2,}$)/;
-  const passwordValidationRegex =
-    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])[a-zA-Z\d!@#$%^&*]{8,}$/;
-
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    let hasPublicEmailError = false;
-    let hasPasswordError = false;
-
-    if (!emailValidationRegex.test(login)) {
-      hasPublicEmailError = true;
-      setPublicEmailErrorMessage(
-        'We apologize, but we only support private email addresses at the moment 😿',
-      );
+  const handleSignUpClick = async () => {
+    if (activeStep === 0) {
+      // Check that all required fields are filled in
+      const values = getValues();
+      if (!values.email || !values.password) {
+        return;
+      }
+      nextStep();
     } else {
-      setPublicEmailErrorMessage('');
+      // Check that all required fields are filled in
+      const values = getValues();
+      if (!values.firstName || !values.lastName || !values.company || !values.position) {
+        return;
+      }
+
+      try {
+        const result = await signUp({
+          variables: {
+            email: values.email,
+            password: values.password,
+            firstName: values.firstName,
+            lastName: values.lastName,
+            company: values.company,
+            position: values.position,
+          },
+        });
+        window.analytics.identify(result.data.signUp.user_id, {
+          name: [values.firstName, values.lastName].join(' '),
+          email: values.email,
+          method: 'Email Signup',
+        });
+        window.analytics.track(
+          'User Started Sign Up',
+          {
+            email: values.email,
+            name: [values.firstName, values.lastName].join(' '),
+          },
+          err => {
+            if (err) {
+              console.error('Error tracking Segment event:', err);
+            }
+          },
+        );
+        // Have a little delay to let the animation play out, before signing in and going through email verification.
+        setTimeout(() => onSignIn(result.data.signUp.sessionId), 2500)
+        nextStep()
+      } catch (e) {
+        console.log(e)
+      }
     }
-    if (!passwordValidationRegex.test(password)) {
-      hasPasswordError = true;
-      setPasswordErrorMessage(
-        'Password must be at least 8 characters long, contain at least one uppercase letter, one lowercase letter and one number',
-      );
-    } else {
-      setPasswordErrorMessage('');
-    }
-    if (hasPublicEmailError || hasPasswordError) {
-      return;
-    }
-    const data = await signUp({
-      variables: { email: login, password, name },
-    });
-    onSignIn(data.data.signUp.sessionId);
-    window.analytics.identify(data.data.signUp.user_id, {
-      name: name,
-      email: login,
-      method: 'Email Signup',
-    });
-    window.analytics.track(
-      'User Started Sign Up',
-      {
-        email: login,
-        name: name,
-      },
-      err => {
-        if (err) {
-          console.error('Error tracking Segment event:', err);
-        }
-      },
-    );
-  };
+  }
+
+  const steps = [
+    {
+      label: 'Sign Up',
+      icon: FiClipboard,
+      children: (
+        <Box
+          maxW={'400px'}
+          background={'white'}
+          mt="auto"
+          mb="auto"
+          w={'100%'}
+          onClick={e => e.stopPropagation()}
+          alignItems={'center'}
+        >
+          <form className="full-width">
+            <Stack spacing={6} w={'100%'}>
+              <Text mt={4} fontSize="3xl">
+                Sign Up
+              </Text>
+              <FormControl isRequired>
+                <FormLabel>Email address</FormLabel>
+                <Input
+                  {...register('email', { required: true })}
+                  placeholder="name@example.com"
+                  isRequired
+                />
+                {errors.email && (
+                  <Text fontSize="xs" color="red.500">
+                    Email is required
+                  </Text>
+                )}
+              </FormControl>
+              <FormControl isRequired>
+                <FormLabel>Password</FormLabel>
+                <Input
+                  {...register('password', { required: true, minLength: 8 })}
+                  type="password"
+                  placeholder="********"
+                  isRequired
+                />
+                {errors.password && (
+                  <Text fontSize="xs" color="red.500">
+                    Password is required
+                  </Text>
+                )}
+              </FormControl>
+              <Button
+                mt={4}
+                type="submit"
+                onClick={handleSignUpClick}
+                isLoading={loading}
+              >
+                Sign up
+              </Button>
+              <Divider mt="12px" mb="12px" />
+              <HStack>
+                <Text fontSize="sm" textAlign="left" fontWeight="400">
+                  Already have an account?
+                </Text>
+                <Link
+                  fontSize="sm"
+                  fontWeight="600"
+                  onClick={() => navigate('/login')}
+                >
+                  Login here
+                </Link>
+              </HStack>
+              <HStack mt={6} mb={6}>
+                <Divider />
+                <Text fontSize="sm" whiteSpace="nowrap" color="muted">
+                  or continue with
+                </Text>
+                <Divider />
+              </HStack>
+              <HStack w={'100%'} justifyContent={'center'}>
+                <Button
+                  size={'md'}
+                  colorScheme="brand"
+                  onClick={onClick}
+                  leftIcon={<GoogleIcon boxSize="5" />}
+                  width="400px"
+                >
+                  Sign up with Google
+                </Button>
+              </HStack>
+            </Stack>
+          </form>
+        </Box>
+      ),
+    },
+    {
+      label: 'Information',
+      icon: FiUser,
+      children: (
+        <Box
+          maxW={'400px'}
+          background={'white'}
+          mt="auto"
+          mb="auto"
+          w={'100%'}
+          alignItems={'center'}
+        >
+          <FormControl isRequired mt={4} size={'xs'}>
+            <FormLabel htmlFor="first-name">First Name</FormLabel>
+            <Input
+              {...register('firstName', {
+                required: true,
+              })}
+              id="first-name"
+              name="firstName"
+              type="text"
+              isRequired
+            />
+          </FormControl>
+          {errors?.firstName && (
+            <Box fontSize={'md'} color={'red'}>
+              {' '}
+            </Box>
+          )}
+
+          <FormControl isRequired size={'xs'} mt={4}>
+            <FormLabel htmlFor="last-name">Last Name</FormLabel>
+            <Input
+              {...register('lastName', {
+                required: true,
+              })}
+              id="last-name"
+              isRequired
+              name="lastName"
+              type="text"
+            />
+          </FormControl>
+          {errors?.lastName && <Box fontSize={'md'} color={'red'}></Box>}
+
+          <FormControl isRequired size={'xs'} mt={4}>
+            <FormLabel htmlFor="company">Company</FormLabel>
+            <Input
+              {...register('company', {
+                required: true,
+              })}
+              id="company"
+              isRequired
+              name="company"
+              type="text"
+            />
+          </FormControl>
+          {errors?.company && <Box fontSize={'md'} color={'red'}></Box>}
+          <FormControl isRequired size={'xs'} mt={4}>
+            <FormLabel htmlFor="position">Position</FormLabel>
+            <Select
+              {...register('position', {
+                required: true,
+              })}
+              id="position"
+              name="position"
+            >
+              <option value="">Select a position</option>
+              <option value="developer">Developer Advocate</option>
+              <option value="designer">Community Manager</option>
+              <option value="product-manager">Leadership</option>
+              <option value="product-manager">Purchasing</option>
+              <option value="product-manager">Project Manager</option>
+            </Select>
+          </FormControl>
+        </Box>
+      ),
+    },
+  ];
 
   return (
     <>
-      <Helmet>
-        <title>Signup</title>
-        <meta name="description" content="Signup" />
-      </Helmet>
       <Grid templateColumns="repeat(2, 1fr)" gap={0} h={'100%'}>
-        <VStack h={'100%'}>
-          <Box
-            maxW={'400px'}
-            background={'white'}
-            mt="auto"
-            mb="auto"
-            w={'100%'}
+        <Center>
+          <Flex
+            alignItems="center"
+            flexDir="column"
+            width={{ base: '100%', md: '50%' }}
+            px="5px"
           >
-            <Center>
-              <form onSubmit={onSubmit} className="full-width">
-                {publicEmailErrorMessage && (
-                  <Alert status="error" mb={4}>
-                    <AlertIcon />
-                    <AlertTitle mr={2}>Error</AlertTitle>
-                    <AlertDescription>
-                      {publicEmailErrorMessage}
-                    </AlertDescription>
-                  </Alert>
-                )}
-                <Stack spacing={6} w={'100%'}>
-                  <Text fontSize="3xl">Sign Up</Text>
-                  <FormControl
-                    isInvalid={Boolean(publicEmailErrorMessage)}
-                    size={'xs'}
-                  >
-                    <FormLabel>Email address</FormLabel>
-                    <Input
-                      type="email"
-                      value={login}
-                      onChange={e => setLogin(e.target.value)}
-                    />
-                  </FormControl>
-                  <FormControl size={'xs'}>
-                    <FormLabel>Name</FormLabel>
-                    <Input
-                      type="text"
-                      value={name}
-                      onChange={e => setName(e.target.value)}
-                    />
-                  </FormControl>
-                  <FormControl isInvalid={Boolean(passwordErrorMessage)}>
-                    <FormLabel>Password</FormLabel>
-                    {error && passwordErrorMessage && (
-                      <Alert status="error" borderRadius={4} mb={4}>
-                        <AlertIcon />
-                        <AlertTitle mr={2}>Error</AlertTitle>
-                        <AlertDescription>
-                          {passwordErrorMessage}
-                        </AlertDescription>
-                      </Alert>
-                    )}
-                    <Input
-                      type="password"
-                      value={password}
-                      onChange={e => setPassword(e.target.value)}
-                    />
-                  </FormControl>
-                  <Button
-                    mt={4}
-                    colorScheme="brand"
-                    type="submit"
-                    isLoading={loading}
-                  >
-                    Sign up
-                  </Button>
-                  <Divider mt="12px" mb="12px" />
-                  <HStack>
-                    <Text fontSize="sm" textAlign="left" fontWeight="400">
-                      Already have an account?
-                    </Text>
-                    <Link
-                      fontSize="sm"
-                      fontWeight="600"
-                      onClick={() => navigate('/login')}
-                    >
-                      Login here
-                    </Link>
-                  </HStack>
-                  <HStack mt={6} mb={6}>
-                    <Divider />
-                    <Text fontSize="sm" whiteSpace="nowrap" color="muted">
-                      or continue with
-                    </Text>
-                    <Divider />
-                  </HStack>
-                  <HStack w={'100%'} justifyContent={'center'}>
+            <Steps activeStep={activeStep}>
+              {steps.map(({ label, icon, children }, index) => (
+                <Step label={label} icon={icon} key={index}>
+                  {children}
+                </Step>
+              ))}
+            </Steps>
+            {activeStep === steps.length ? (
+              <Flex px={4} py={4} width="100%" flexDirection="column">
+                <Heading fontSize="xl" textAlign="center">
+                  <Box mt="15px">
+                    <Heading>Congratulations!</Heading>
+                    <Text>You have completed the onboarding process.</Text>
+                  </Box>
+                  <Lottie
+                    options={{
+                      animationData: animationDataComplete, // this is the json object of the lottie file
+                      loop: false,
+                      autoplay: true,
+                    }}
+                    height={200}
+                    width={200}
+                  />
+                </Heading>
+              </Flex>
+            ) : (
+              <Center>
+                <Flex alignItems="center" width="100%">
+                  <Spacer />
+                  {activeStep === 1 && (
                     <Button
-                      size={'md'}
-                      onClick={() => onClick('/onboarding')}
-                      leftIcon={<GoogleIcon boxSize="5" />}
+                      mt={4}
+                      size="md"
+                      type="submit"
+                      onClick={handleSignUpClick}
+                      isLoading={loading}
+                      width="400px"
+                      colorScheme="brand"
                     >
-                      Sign up with Google
+                      Finish
                     </Button>
-                  </HStack>
-                </Stack>
-              </form>
-            </Center>
-          </Box>
-        </VStack>
+                  )}
+                </Flex>
+              </Center>
+            )}
+          </Flex>
+        </Center>
         <Box
           w={'100%'}
           h={'100%'}
@@ -211,7 +327,7 @@ export function Signup() {
             options={{
               loop: true,
               autoplay: true,
-              animationData: animationData,
+              animationData: animationDataHero,
               rendererSettings: {
                 preserveAspectRatio: 'xMidYMid slice',
               },


### PR DESCRIPTION
The user sign up process contained too many steps, including the requirement for a credit card. This is reducing the number of potential users, and has been decided to streamline this whole process
 - Add two steps to the initial user sign up, first to add email and password (auth details), then personal info - first, last names, company and position.
 - Update all GQL calls to correctly map the new data structure of first and last name, instead of just name, and the two new user fields company and position.
 - Once a user completes the sign in, they will go through email verification as before.
 - If the user is the first of their company (or that company workspace does not have auto-join enabled) they will be prompted with the workspace setup screen *once*. ALL users after them just log in after verification
[SignUp-WIP2.webm](https://user-images.githubusercontent.com/6631656/222555267-dfa144a7-72fa-4e95-94de-5de778932dbd.webm)

